### PR TITLE
Code cleanups

### DIFF
--- a/src/tagging_view_handler.cpp
+++ b/src/tagging_view_handler.cpp
@@ -479,25 +479,22 @@ bool TaggingViewHandler::has_feature_key(const osmium::TagList& tags) {
             return true;
         } else if (!strcmp(t.key(), "university")) {
             return true;
-        } else if (is_a_x_key_key(t.key(), "historic")) {
-            return true;
-        } else if (is_a_x_key_key(t.key(), "razed")) {
-            return true;
-        } else if (is_a_x_key_key(t.key(), "demolished")) {
-            return true;
-        } else if (is_a_x_key_key(t.key(), "abandoned")) {
-            return true;
-        } else if (is_a_x_key_key(t.key(), "disused")) {
-            return true;
-        } else if (is_a_x_key_key(t.key(), "construction")) {
-            return true;
-        } else if (is_a_x_key_key(t.key(), "proposed")) {
-            return true;
-        } else if (is_a_x_key_key(t.key(), "temporary")) {
-            return true;
-        } else if (is_a_x_key_key(t.key(), "TMC")) {
-            return true;
-        } else if (!strcmp(t.key(), "pipeline")) {
+        } else {
+            const auto keys = { "historic", "razed", "demolished",
+                                "abandoned", "disused", "construction",
+                                "proposed", "temporary", "TMC",
+                              };
+            for (auto &&k : keys) {
+                if (is_a_x_key_key(t.key(), k)) {
+                    // razed=yes is not considered a feature key
+                    if (strcmp(t.value(), "yes") || strcmp(t.key(), k)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        if (!strcmp(t.key(), "pipeline")) {
             return true;
         } else if (!strcmp(t.key(), "club")) {
             return true;

--- a/src/tagging_view_handler.cpp
+++ b/src/tagging_view_handler.cpp
@@ -483,6 +483,7 @@ bool TaggingViewHandler::has_feature_key(const osmium::TagList& tags) {
             const auto keys = { "historic", "razed", "demolished",
                                 "abandoned", "disused", "construction",
                                 "proposed", "temporary", "TMC",
+                                "removed",
                               };
             for (auto &&k : keys) {
                 if (is_a_x_key_key(t.key(), k)) {

--- a/src/tagging_view_handler.cpp
+++ b/src/tagging_view_handler.cpp
@@ -514,6 +514,8 @@ bool TaggingViewHandler::has_feature_key(const osmium::TagList& tags) {
             return true;
         } else if (!strcmp(t.key(), "room")) {
             return true;
+        } else if (!strcmp(t.key(), "attraction")) {
+            return true;
         }
     }
     return false;

--- a/test/t/test_highway_view.cpp
+++ b/test/t/test_highway_view.cpp
@@ -27,74 +27,74 @@ bool check_turn(const char* value) {
 TEST_CASE("test valid turn:lane values") {
 
     SECTION("single values") {
-        REQUIRE(check_turn("left") == true);
-        REQUIRE(check_turn("right") == true);
-        REQUIRE(check_turn("through") == true);
-        REQUIRE(check_turn("slight_left") == true);
-        REQUIRE(check_turn("slight_right") == true);
+        REQUIRE(check_turn("left"));
+        REQUIRE(check_turn("right"));
+        REQUIRE(check_turn("through"));
+        REQUIRE(check_turn("slight_left"));
+        REQUIRE(check_turn("slight_right"));
     }
 
     SECTION("single invalid values") {
-        REQUIRE(check_turn(" left") == false);
-        REQUIRE(check_turn("right ") == false);
-        REQUIRE(check_turn("thr ough") == false);
-        REQUIRE(check_turn(" slight_left") == false);
-        REQUIRE(check_turn("slidght_right") == false);
-        REQUIRE(check_turn("") == false);
-        REQUIRE(check_turn("d") == false);
-        REQUIRE(check_turn(" ") == false);
-        REQUIRE(check_turn("     ") == false);
+        REQUIRE_FALSE(check_turn(" left"));
+        REQUIRE_FALSE(check_turn("right "));
+        REQUIRE_FALSE(check_turn("thr ough"));
+        REQUIRE_FALSE(check_turn(" slight_left"));
+        REQUIRE_FALSE(check_turn("slidght_right"));
+        REQUIRE_FALSE(check_turn(""));
+        REQUIRE_FALSE(check_turn("d"));
+        REQUIRE_FALSE(check_turn(" "));
+        REQUIRE_FALSE(check_turn("     "));
     }
 
     SECTION("valid multiple values") {
-        REQUIRE(check_turn("left|through") == true);
-        REQUIRE(check_turn("through|through|right") == true);
-        REQUIRE(check_turn("through|through|slight_right|right") == true);
-        REQUIRE(check_turn("none|none|slight_right") == true);
+        REQUIRE(check_turn("left|through"));
+        REQUIRE(check_turn("through|through|right"));
+        REQUIRE(check_turn("through|through|slight_right|right"));
+        REQUIRE(check_turn("none|none|slight_right"));
     }
 
     SECTION("valid multiple values with skipped none values") {
-        REQUIRE(check_turn("left|") == true);
-        REQUIRE(check_turn("||right") == true);
-        REQUIRE(check_turn("left||right") == true);
-        REQUIRE(check_turn("") == false);
-        REQUIRE(check_turn("||") == false);
+        REQUIRE(check_turn("left|"));
+        REQUIRE(check_turn("||right"));
+        REQUIRE(check_turn("left||right"));
+        REQUIRE_FALSE(check_turn(""));
+        REQUIRE_FALSE(check_turn("||"));
     }
 
     SECTION("invalid multiple values") {
-        REQUIRE(check_turn("left|throuXgh") == false);
-        REQUIRE(check_turn("throuXgh|through|right") == false);
-        REQUIRE(check_turn("through|throXugh|slight_right|right") == false);
-        REQUIRE(check_turn("none||slight_right") == true);
-        REQUIRE(check_turn("|through|slight_right|right") == true);
-        REQUIRE(check_turn("through|through|slight_right|") == true);
-        REQUIRE(check_turn("through|through||") == true);
+        REQUIRE_FALSE(check_turn("left|throuXgh"));
+        REQUIRE_FALSE(check_turn("throuXgh|through|right"));
+        REQUIRE_FALSE(check_turn("through|throXugh|slight_right|right"));
+        REQUIRE(check_turn("none||slight_right"));
+        REQUIRE(check_turn("|through|slight_right|right"));
+        REQUIRE(check_turn("through|through|slight_right|"));
+        REQUIRE(check_turn("through|through||"));
     }
 
     SECTION("values with semicolons") {
-        REQUIRE(check_turn("left;through;right") == true);
-        REQUIRE(check_turn("left;through") == true);
-        REQUIRE(check_turn("left;through|right") == true);
-        REQUIRE(check_turn("left|through;slight_right") == true);
-        REQUIRE(check_turn("left|through|through;slight_right") == true);
-        REQUIRE(check_turn("left|through;slight_right|right|right") == true);
-        REQUIRE(check_turn("left|through;slight_right;right|right") == true);
-        REQUIRE(check_turn("left|through;slight_right|right") == true);
-        REQUIRE(check_turn("none|none|slight_right;right") == true);
+        REQUIRE(check_turn("left;through;right"));
+        REQUIRE(check_turn("left;through"));
+        REQUIRE(check_turn("left;through|right"));
+        REQUIRE(check_turn("left|through;slight_right"));
+        REQUIRE(check_turn("left|through|through;slight_right"));
+        REQUIRE(check_turn("left|through;slight_right|right|right"));
+        REQUIRE(check_turn("left|through;slight_right;right|right"));
+        REQUIRE(check_turn("left|through;slight_right|right"));
+        REQUIRE(check_turn("none|none|slight_right;right"));
     }
 
     SECTION("invalid values with semicolons") {
-        REQUIRE(check_turn("left;through;rEght") == false);
-        REQUIRE(check_turn("left;throuXh") == false);
-        REQUIRE(check_turn("leDt;through|right") == false);
-        REQUIRE(check_turn("|leDt;through|right") == false);
-        REQUIRE(check_turn(";left;through|right") == false);
-        REQUIRE(check_turn("left|tDhrough|through;slight_right") == false);
-        REQUIRE(check_turn("left|through;back|right|right") == false);
-        REQUIRE(check_turn("left|through;;slight_Dright;right|right") == false);
-        REQUIRE(check_turn("left|through;slight_right|riDght") == false);
-        REQUIRE(check_turn("none||slight_right;right") == true);
-        REQUIRE(check_turn("none|slight_right;right;;") == false);
-        REQUIRE(check_turn("none|;|") == false);
+        REQUIRE_FALSE(check_turn("left;through;rEght"));
+        REQUIRE_FALSE(check_turn("left;throuXh"));
+        REQUIRE_FALSE(check_turn("leDt;through|right"));
+        REQUIRE_FALSE(check_turn("|leDt;through|right"));
+        REQUIRE_FALSE(check_turn(";left;through|right"));
+        REQUIRE_FALSE(check_turn("left|tDhrough|through;slight_right"));
+        REQUIRE_FALSE(check_turn("left|through;back|right|right"));
+        REQUIRE_FALSE(check_turn("left|through;;slight_Dright;right|right"));
+        REQUIRE_FALSE(check_turn("left|through;slight_right|riDght"));
+        REQUIRE(check_turn("none||slight_right;right"));
+        REQUIRE_FALSE(check_turn("none|slight_right;right;;"));
+        REQUIRE_FALSE(check_turn("none|;|"));
     }
 }

--- a/test/t/test_tagging_view.cpp
+++ b/test/t/test_tagging_view.cpp
@@ -25,36 +25,36 @@ TEST_CASE("is_a_x_key_key") {
 
     SECTION("short_name") {
         const char* key = "short_name";
-        REQUIRE(TaggingViewHandler::is_a_x_key_key(key, whitelist_base) == true);
+        REQUIRE(TaggingViewHandler::is_a_x_key_key(key, whitelist_base));
     }
 
     SECTION("official_name") {
         const char* key = "official_name";
-        REQUIRE(TaggingViewHandler::is_a_x_key_key(key, whitelist_base) == true);
+        REQUIRE(TaggingViewHandler::is_a_x_key_key(key, whitelist_base));
     }
 
     SECTION("short_name:ru") {
         const char* key = "short_name:ru";
-        REQUIRE(TaggingViewHandler::is_a_x_key_key(key, whitelist_base) == true);
+        REQUIRE(TaggingViewHandler::is_a_x_key_key(key, whitelist_base));
     }
 
     SECTION("named_entity") {
         const char* key = "named_entity";
-        REQUIRE(TaggingViewHandler::is_a_x_key_key(key, whitelist_base) == false);
+        REQUIRE_FALSE(TaggingViewHandler::is_a_x_key_key(key, whitelist_base));
     }
 
     SECTION("railway:name") {
         const char* key = "railway:name";
-        REQUIRE(TaggingViewHandler::is_a_x_key_key(key, whitelist_base) == true);
+        REQUIRE(TaggingViewHandler::is_a_x_key_key(key, whitelist_base));
     }
 
     SECTION("name") {
         const char* key = "name";
-        REQUIRE(TaggingViewHandler::is_a_x_key_key(key, whitelist_base) == true);
+        REQUIRE(TaggingViewHandler::is_a_x_key_key(key, whitelist_base));
     }
 
     SECTION("highway") {
         const char* key = "highway";
-        REQUIRE(TaggingViewHandler::is_a_x_key_key(key, whitelist_base) == false);
+        REQUIRE_FALSE(TaggingViewHandler::is_a_x_key_key(key, whitelist_base));
     }
 }


### PR DESCRIPTION
 - use REQUIRE directly on "true" bool function results, and use REQUIRE_FALSE to test for false ones
 - refactor ```TaggingViewHandler::has_feature_key()``` a bit to ignore some nonsense tags without code duplication
 - add 2 more tags as feature keys to reduce the false positives in my personal tagging error list