### PR TITLE
Add highway=busway

### DIFF
--- a/src/highway_view_handler.cpp
+++ b/src/highway_view_handler.cpp
@@ -690,7 +690,7 @@ void HighwayViewHandler::highway_unknown_way(const osmium::Way& way) {
             || !strcmp(highway, "construction") || !strcmp(highway, "disused") || !strcmp(highway, "abandoned")
             || !strcmp(highway, "proposed") || !strcmp(highway, "platform") || !strcmp(highway, "road")
             || !strcmp(highway, "elevator") || !strcmp(highway, "corridor") || !strcmp(highway, "no")
-            || !strcmp(highway, "emergency_bay") || !strcmp(highway, "razed")) {
+            || !strcmp(highway, "emergency_bay") || !strcmp(highway, "razed") || !strcmp(highway, "busway")) {
         return;
     }
     if (way.is_closed() && (!strcmp(highway, "services") || !strcmp(highway, "rest_area") || !strcmp(highway, "traffic_island"))) {


### PR DESCRIPTION
Add highway=busway to the list of known highway types

Fixes unknown_way errors, like here: http://tools.geofabrik.de/osmi/?view=highways&lon=5.85623&lat=51.83450&zoom=18