### PR TITLE
Add item 'allotments' to PlacesHandler::place_value_ok

### DIFF
--- a/src/places_handler.cpp
+++ b/src/places_handler.cpp
@@ -134,6 +134,9 @@ bool PlacesHandler::place_value_ok(const char* value) {
     if (!strcmp(value, "farm")) {
         return true;
     }
+    if (!strcmp(value, "allotments")) {
+        return true;
+    }
     if (!strcmp(value, "subdivision")) {
         return true;
     }


### PR DESCRIPTION
There is a missed key `allotments` in the places checker. [Link to a page on OSM wiki](https://wiki.openstreetmap.org/wiki/Tag%3Aplace%3Dallotments). 