### PR TITLE
Allow population=0

### DIFF
--- a/src/places_handler.cpp
+++ b/src/places_handler.cpp
@@ -232,7 +232,7 @@ void PlacesHandler::add_feature(std::unique_ptr<OGRGeometry>&& geometry, const o
         long int population = std::strtol(popstr, &rest, 10);
         if (*rest) {
             add_error(osm_object, id, geomtype, "characters after population number", popstr);
-        } else if (population < 20000000000 && population > 0) {
+        } else if (population < 20000000000 && population >= 0) {
             feature.set_field("population", static_cast<int>(population));
             check_population(osm_object, id, geomtype, place_value, population);
         } else {


### PR DESCRIPTION
Some places really have no one living there; 0 is a valid population number.

See for example: https://tools.geofabrik.de/osmi/?view=places&lon=6.08140&lat=50.02694&zoom=12&baselayer=Geofabrik%20Standard&overlays=errors_unknown_place_type%2Cerrors_population_format%2Cerrors_place_without_name%2Cerrors_pop_type_mismatch%2Cpopulation